### PR TITLE
Testing against the build package not the source.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ ENV/
 
 # Private notes
 TODO.md
+
+# pytest results
+test_results

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-"""Unit test package for whisk."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 import shutil
 from pathlib import Path
 from cookiecutter import main
+import whisk
 from whisk.whisk import cookiecutter_template_dir
 
 args = {

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import datetime as dt
 from subprocess import check_output, CalledProcessError
-from tests.conftest import system_check
+from conftest import system_check
 
 
 def no_curlies(filepath):


### PR DESCRIPTION
Since there was an `__init__.py` file in `tests`, the local source code was loading and not the whisk package we want to test. Removed this and adjusted some imports so tox tests the actual package and not the source code.

Background: https://github.com/tox-dev/tox/issues/514#issuecomment-327779367