### PR TITLE
Add slugignore and comment to requirements.txt

### DIFF
--- a/whisk/template/{{ cookiecutter.repo_name }}/.slugignore
+++ b/whisk/template/{{ cookiecutter.repo_name }}/.slugignore
@@ -1,0 +1,6 @@
+# This is used to remove files before heroku deployment
+# More info: https://devcenter.heroku.com/articles/slug-compiler#ignoring-files-with-slugignore
+
+# Default project files not needed for deployment
+/data
+/notebooks

--- a/whisk/template/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/whisk/template/{{ cookiecutter.repo_name }}/requirements.txt
@@ -19,6 +19,7 @@ pytest==4.6.5 # Tests
 pytest-runner==5.1 # Tests
 
 ### Common Data Science Packages
+# Already have a list of project requirements? Remove conflicting packages.
 cloudpickle # For serializing constructs that Pickle can't.
 ipython
 jupyter


### PR DESCRIPTION
This adds a .slugignore to remove not-needed files from Heroku deploys and adds comment to requirements.txt for conflicts.